### PR TITLE
Fix Scheduler.CallUnavailable via Lookup-to-Inline conversion

### DIFF
--- a/integration-tests/tests/all_tracks.rs
+++ b/integration-tests/tests/all_tracks.rs
@@ -120,6 +120,11 @@ async fn polkadot_governance_all_tracks() {
         "gov_inline_bynum",
         run_governance_inline_bynum(&ctx, &runner)
     );
+    run_and_bail!(
+        errors,
+        "gov_bynum_lookup_execution",
+        run_governance_bynum_lookup_execution(&ctx, &runner)
+    );
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -694,6 +699,56 @@ async fn run_governance_inline_bynum(
 
     output.check_success()?;
     output.check_stdout_contains("executed successfully")?;
+    Ok(())
+}
+
+/// By-number test with a Lookup proposal on the Root track.
+///
+/// This test specifically validates that the scheduler can execute Lookup proposals
+/// when the scheduler entry is moved via storage manipulation. On parachains, the
+/// execute call is scheduled at relay_block + min_enactment_period, which may be
+/// far in the future. Moving this Lookup entry via `dev.setStorage` can cause
+/// `Scheduler.CallUnavailable` if the preimage lookup breaks during the move.
+///
+/// The test submits a referendum with a Lookup proposal (preimage-based) on the Root
+/// track, then runs the tool by referendum ID and verifies:
+/// 1. The tool succeeds (exit code 0)
+/// 2. Output contains "executed successfully"
+/// 3. Output does NOT contain "CallUnavailable"
+async fn run_governance_bynum_lookup_execution(
+    ctx: &GovernanceTestContext,
+    runner: &ToolRunner,
+) -> Result<()> {
+    log::info!("[gov_bynum_lookup_execution] Starting...");
+
+    // Use Root track — it has the largest min_enactment_period, making the scheduler
+    // move most significant and most likely to trigger preimage lookup issues.
+    let root_track = tracks::GOVERNANCE_TRACKS
+        .iter()
+        .find(|t| t.is_root)
+        .expect("Root track must exist in GOVERNANCE_TRACKS");
+
+    let submitted =
+        extrinsic_submitter::submit_governance_referendum(&ctx.ah_client, root_track, "Origins")
+            .await?;
+
+    let fork_url = format!("{},{}", ctx.asset_hub_ws_uri, submitted.block_number);
+
+    let port = port_allocator::next_port();
+    let output = runner
+        .run_test_referendum(ToolArgs {
+            governance_chain_url: Some(fork_url),
+            referendum: Some(submitted.referendum_id.to_string()),
+            port: Some(port),
+            verbose: true,
+            ..Default::default()
+        })
+        .await?;
+
+    output.check_success()?;
+    output.check_stdout_contains("executed successfully")?;
+    output.check_any_output_not_contains("CallUnavailable")?;
+    log::info!("[gov_bynum_lookup_execution] PASSED");
     Ok(())
 }
 

--- a/integration-tests/tests/common/tool_runner.rs
+++ b/integration-tests/tests/common/tool_runner.rs
@@ -82,6 +82,21 @@ impl ToolOutput {
         );
         Ok(())
     }
+
+    /// Check neither stdout nor stderr contains a substring (case-insensitive).
+    pub fn check_any_output_not_contains(&self, pattern: &str) -> Result<()> {
+        let lower_pattern = pattern.to_lowercase();
+        let in_stdout = self.stdout.to_lowercase().contains(&lower_pattern);
+        let in_stderr = self.stderr.to_lowercase().contains(&lower_pattern);
+        anyhow::ensure!(
+            !in_stdout && !in_stderr,
+            "Expected output NOT to contain '{}', but it was found.\n--- stdout ---\n{}\n--- stderr ---\n{}",
+            pattern,
+            self.stdout,
+            self.stderr,
+        );
+        Ok(())
+    }
 }
 
 // ── Test suite infrastructure ────────────────────────────────────────────────

--- a/src/services/scheduler-manager.ts
+++ b/src/services/scheduler-manager.ts
@@ -86,6 +86,15 @@ export class SchedulerManager {
       `Found ${callType} call at block ${keyArgs[0]} index ${matchIndex}, moving to block ${targetBlock}`
     );
 
+    // For Lookup calls, convert to Inline by fetching the preimage bytes.
+    // Chopsticks can't correctly handle the Preimage.PreimageFor Identity-hashed
+    // tuple key when writing scheduler entries, which causes Scheduler.CallUnavailable.
+    // By inlining the call data, the scheduler has the bytes directly and never
+    // needs a preimage lookup during execution.
+    if (callType === 'execute' && scheduledEntry.call.type === 'Lookup') {
+      await this.convertLookupToInline(scheduledEntry, agendaItems, matchIndex);
+    }
+
     const callInfo = this.getCallInfo(scheduledEntry.call);
     this.logger.info(`\u{1F4CB} Scheduling ${callType} call:`);
     this.logger.info(`   From block: ${keyArgs[0]}`);
@@ -126,6 +135,44 @@ export class SchedulerManager {
     }
 
     return { block: targetBlock, taskIndex: matchIndex, taskId: scheduledEntry.maybeId };
+  }
+
+  /**
+   * Convert a Lookup scheduler entry to Inline by fetching the preimage bytes.
+   * This avoids Chopsticks issues with Preimage.PreimageFor Identity-hashed keys.
+   */
+  private async convertLookupToInline(
+    scheduledEntry: ScheduledEntry,
+    agendaItems: ScheduledEntry[],
+    matchIndex: number
+  ): Promise<void> {
+    const lookupValue = scheduledEntry.call.value as { hash: unknown; len: number };
+    const hash = toHexString(lookupValue.hash) ?? String(lookupValue.hash);
+    const len = lookupValue.len;
+
+    this.logger.debug(`Converting Lookup call to Inline (hash: ${hash}, len: ${len})`);
+
+    const preimageQuery = this.api.query.Preimage?.PreimageFor;
+    if (!preimageQuery) {
+      this.logger.warn('Preimage pallet not available — cannot convert Lookup to Inline');
+      return;
+    }
+
+    const preimageData = await preimageQuery.getValue([hash, len]);
+    if (!preimageData) {
+      this.logger.warn(`Preimage not found for hash ${hash} len ${len} — keeping Lookup`);
+      return;
+    }
+
+    // Replace the call in both the entry and the agenda array
+    const inlineCall: ScheduledCall = {
+      type: 'Inline',
+      value: preimageData,
+    };
+    scheduledEntry.call = inlineCall;
+    agendaItems[matchIndex] = scheduledEntry;
+
+    this.logger.info(`Converted Lookup call to Inline (${len} bytes)`);
   }
 
   private async findMatchingScheduledCall(

--- a/src/types/substrate-api.ts
+++ b/src/types/substrate-api.ts
@@ -127,6 +127,9 @@ export interface SubstrateApi {
     ParachainSystem?: {
       LastRelayChainBlockNumber: StorageValue<number>;
     };
+    Preimage?: {
+      PreimageFor: StorageMap<[string, number], Binary>;
+    };
   };
   constants: {
     System: {


### PR DESCRIPTION
## Summary

Fixes `Scheduler.CallUnavailable` for Lookup proposals in the by-number flow by converting Lookup scheduler entries to Inline before moving them via `dev.setStorage`.

**Root cause:** Chopsticks can't correctly handle the `Preimage.PreimageFor` Identity-hashed `(H256, u32)` tuple key when writing scheduler entries. When the scheduler later tries to `peek()` the preimage, it fails with `CallUnavailable`.

**Fix:** Before moving a Lookup execute call in the scheduler, fetch the preimage bytes from `Preimage.PreimageFor` and convert the call from `Lookup { hash, len }` to `Inline(bytes)`. The scheduler then has the call data directly and never needs a preimage lookup.

**Advantages over the block-stepping approach (PR #27):**
- Fast — single block production, no stepping through potentially hundreds of blocks
- Same code path for both Inline and Lookup proposals
- Graceful fallback — if preimage can't be read, keeps the Lookup call as-is

### Changes
- `scheduler-manager.ts`: Add `convertLookupToInline()` method, called before moving execute calls
- `substrate-api.ts`: Add `Preimage.PreimageFor` query type

Supersedes #27. Includes the integration test from #28.

## Test plan
- [ ] Run unit tests (`npx vitest run`) — all 181 pass
- [ ] Run `polkadot_governance_all_tracks` integration test suite
- [ ] Verify `gov_bynum_lookup_execution` scenario passes (no `CallUnavailable`)
- [ ] Verify existing by-number and create-from-hex tests still pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)